### PR TITLE
Modify customFlags to be set on MP rather than event itself

### DIFF
--- a/CriteoEventForwarder.js
+++ b/CriteoEventForwarder.js
@@ -32,13 +32,15 @@
 
     var constructor = function () {
         var self = this,
-            reportingService;
+            reportingService,
+            mpCustomFlags;
 
         setDefaultCriteoEvents();
 
         self.name = name;
 
-        function initForwarder(forwarderSettings, service, testMode) {
+        function initForwarder(forwarderSettings, service, testMode, trackerId, userAttributes, userIdentities, appVersion, appName, customFlags) {
+            mpCustomFlags = customFlags;
             if (!testMode) {
                 reportingService = service;
                 settings = forwarderSettings;
@@ -120,9 +122,9 @@
             }
         }
 
-        function modifySetSiteTypeEvent(event) {
-            if (event.CustomFlags && event.CustomFlags[CRITEO_SITETYPE]) {
-                setSiteTypeEvent.type = event.CustomFlags[CRITEO_SITETYPE];
+        function modifySetSiteTypeEvent() {
+            if (mpCustomFlags && mpCustomFlags[CRITEO_SITETYPE]) {
+                setSiteTypeEvent.type = mpCustomFlags[CRITEO_SITETYPE];
             } else {
                 setSiteTypeEvent.type = 'd';
             }

--- a/test/tests.js
+++ b/test/tests.js
@@ -359,11 +359,14 @@ describe('Criteo Integration', function () {
     });
 
     it('should set setSiteType of m or t when these are set as event attributes', function(done) {
+        mParticle.forwarder.init({
+            apiKey: 'abcde'
+        }, reportService, true, null, null, null, null, null, {CRITEO_SITETYPE: 'm'});
+
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'homepage',
             CustomFlags: {
-                CRITEO_SITETYPE: 'm',
                 CRITEO_VIEW_HOMEPAGE: true
             }
         });
@@ -378,11 +381,13 @@ describe('Criteo Integration', function () {
 
         criteo_q = [];
 
+        mParticle.forwarder.init({
+            apiKey: 'abcde'
+        }, reportService, true, null, null, null, null, null, {CRITEO_SITETYPE: 't'});
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'homepage',
             CustomFlags: {
-                CRITEO_SITETYPE: 't',
                 CRITEO_VIEW_HOMEPAGE: true
             }
         });


### PR DESCRIPTION
Jetlagged and so started doing docs and caught something :).

WRT `customFlags`, I originally thought it was found on the `event` object but this is only the case for `logPageView`, which allows you to set `customFlags` for each `logPageEvent`.  For each `eCommerceEvent`, there are no `customFlags`, and so we need to pass the `setSiteType` flag on the MP.customFlags when the forwarder inits.

This is now fixed and so `customFlags` will be used from MP.customFlags which is found when mParticle.init is called and we have customFlags on the `mParticle.config` object.  Happy to explain in person in the morning.